### PR TITLE
修复为较小目标 MPI 进程保存数据时，叶层太小引起 MPI 数据分区不全在盒子方向导致的基函数划分区间重叠问题。

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 [![Build Status](https://github.com/deltaeecs/MoM_Kernels.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/deltaeecs/MoM_Kernels.jl/actions/workflows/CI.yml?query=branch%3Amaster)
 [![Coverage](https://codecov.io/gh/deltaeecs/MoM_Kernels.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/deltaeecs/MoM_Kernels.jl)
 
-![Size](https://img.shields.io/github/repo-size/deltaeecs/MoM_Kernels.jl
-)
+![Size](https://img.shields.io/github/repo-size/deltaeecs/MoM_Kernels.jl)
 ![Downloads](https://img.shields.io/github/downloads/deltaeecs/MoM_Kernels.jl/total)
 ![License](https://img.shields.io/github/license/deltaeecs/MoM_Kernels.jl)
 

--- a/src/Extends/IOs.jl
+++ b/src/Extends/IOs.jl
@@ -150,9 +150,9 @@ end
 
 根据给定的盒子数 `nCubes` 、多极子数 `sizePoles`、进程数 `np` 返回该层辐射函数的三个维度的划分数量。
 """
-function get_partition(nCubes, sizePoles, np)
-    temp = slicedim2mpi((sizePoles, nCubes), np)
-    partition = (temp[1], 1, temp[2])
+function get_partition(nCubes, sizePoles, np; isleaf = false)
+    temp = slicedim2partition((sizePoles, nCubes), np)
+    partition = isleaf ? (1, 1, np) : (temp[1], 1, temp[2])
     return partition
 end
 
@@ -174,7 +174,7 @@ function saveLevel(level, np = ParallelParams.nprocs; dir="", kcubeIndices = not
     # 多极子数
     sizePoles   =   length(level.poles.r̂sθsϕs)
     # 层内划分
-    partition =   get_partition(length(cubes), sizePoles, np)
+    partition   =   get_partition(length(cubes), sizePoles, np; isleaf = level.isleaf)
     # 保存盒子并获取该层盒子的分布索引
     indices = saveCubes(cubes, partition; name = "Level_$(level.ID)_Cubes", dir=dir, kcubeIndices = kcubeIndices)
 

--- a/src/Extends/MPIArray_utlis.jl
+++ b/src/Extends/MPIArray_utlis.jl
@@ -1,15 +1,14 @@
 using Primes
 
-@doc """
-    slicedim2mpi(sz::Int, nc::Int)
-    slicedim2mpi(dims, nc::Int)
+"""
+    slicedim2bounds(sz::Int, nc::Int)
 
-将区间 `1:sz` 划分为 `nc` 个区间。
+将区间 `1:sz` 划分为 `nc` 个区间并返回区间上下界。
 *从 [MPIArray4MoMs](https://github.com/deltaeecs/MPIArray4MoMs.jl) 借的！
 为的是避免提前引入 MPI 导致在集群上的 bug。因此该函数的修改必须与 
 [MPIArray4MoMs](https://github.com/deltaeecs/MPIArray4MoMs.jl) 同步。*
 """
-function slicedim2mpi(sz::Int, nc::Int)
+function slicedim2bounds(sz::Int, nc::Int)
     if sz >= nc
         chunk_size = div(sz,nc)
         remainder = rem(sz,nc)
@@ -27,7 +26,16 @@ function slicedim2mpi(sz::Int, nc::Int)
         return [[1:(sz+1);]; zeros(Int, nc-sz)]
     end
 end
-function slicedim2mpi(dims, nc::Int)
+
+"""
+    slicedim2bounds(dims, nc::Int)
+
+将区间 `dims` 划分为 `nc` 个区间并返回区间上下界。
+*从 [MPIArray4MoMs](https://github.com/deltaeecs/MPIArray4MoMs.jl) 借的！
+为的是避免提前引入 MPI 导致在集群上的 bug。因此该函数的修改必须与 
+[MPIArray4MoMs](https://github.com/deltaeecs/MPIArray4MoMs.jl) 同步。*
+"""
+function slicedim2partition(dims, nc::Int)
     dims = [dims...]
     chunks = ones(Int, length(dims))
     f = sort!(collect(keys(factor(nc))), rev=true)
@@ -56,59 +64,68 @@ end
 
 @doc """
     sizeChunks2cuts(Asize, chunks)
+    sizeChunks2cuts(Asize::Int, chunks)
+    sizeChunks2cuts(Asize, chunks::Int)
+    sizeChunks2cuts(Asize::Int, chunks::Int)
 
 将数组大小 `Asize` 按 `chunks` 进行分块。
+*从 [MPIArray4MoMs](https://github.com/deltaeecs/MPIArray4MoMs.jl) 借的！
+为的是避免提前引入 MPI 导致在集群上的 bug。因此该函数的修改必须与 
+[MPIArray4MoMs](https://github.com/deltaeecs/MPIArray4MoMs.jl) 同步。*
 """
 function sizeChunks2cuts(Asize, chunks)
-    map(slicedim2mpi, Asize, chunks)
-end
-function sizeChunks2cuts(Asize, chunks::Int)
-    map(slicedim2mpi, Asize, (chunks, ))
+    map(slicedim2bounds, Asize, chunks)
 end
 function sizeChunks2cuts(Asize::Int, chunks)
-    map(slicedim2mpi, (Asize, ), chunks)
+    map(slicedim2bounds, (Asize, ), chunks)
+end
+function sizeChunks2cuts(Asize, chunks::Int)
+    map(slicedim2bounds, Asize, (chunks, ))
 end
 function sizeChunks2cuts(Asize::Int, chunks::Int)
-    map(slicedim2mpi, (Asize, ), (chunks, ))
+    map(slicedim2bounds, (Asize, ), (chunks, ))
 end
 
 @doc """
-    sizeChunksCuts2indices(Asize, chunks, cuts::Tuple)
+    sizeChunksCuts2indices(Asize, nchunk, cuts::Tuple)
+    sizeChunksCuts2indices(Asize, nchunk, cuts::Vector{I}) where{I<:Integer}
 
+根据数组大小 `Asize` 分块数量 `nchunk` 以及各块索引区间 `cuts` 计算各块的索引。
+*从 [MPIArray4MoMs](https://github.com/deltaeecs/MPIArray4MoMs.jl) 借的！
+为的是避免提前引入 MPI 导致在集群上的 bug。因此该函数的修改必须与 
+[MPIArray4MoMs](https://github.com/deltaeecs/MPIArray4MoMs.jl) 同步。*
 """
-function sizeChunksCuts2indices(Asize, chunks, cuts::Tuple)
+function sizeChunksCuts2indices(Asize, nchunk, cuts::Tuple)
     n = length(Asize)
-    idxs = Array{NTuple{n,UnitRange{Int}}, n}(undef, chunks...)
-    for cidx in CartesianIndices(tuple(chunks...))
+    idxs = Array{NTuple{n,UnitRange{Int}}, n}(undef, nchunk...)
+    for cidx in CartesianIndices(tuple(nchunk...))
         if n > 0
             idxs[cidx.I...] = ntuple(i -> (cuts[i][cidx[i]]:cuts[i][cidx[i] + 1] - 1), n)
         else
             throw("0 dim array not supported.")
         end
     end
-
     return idxs
 end
-function sizeChunksCuts2indices(Asize, chunks, cuts::Vector{I}) where{I<:Integer}
+function sizeChunksCuts2indices(Asize, nchunk, cuts::Vector{I}) where{I<:Integer}
     n = length(Asize)
-    idxs = Array{NTuple{n,UnitRange{Int}}, n}(undef, chunks...)
-    for cidx in CartesianIndices(tuple(chunks...))
+    idxs = Array{NTuple{n,UnitRange{Int}}, n}(undef, nchunk...)
+    for cidx in CartesianIndices(tuple(nchunk...))
         idxs[cidx.I...] = (cuts[cidx[1]]:cuts[cidx[1] + 1] - 1, )
     end
-
     return idxs
 end
 
-
 """
-    sizeChunks2idxs(Asize, chunks)
+    sizeChunks2idxs(Asize, nchunk)
 
-    Borrowed form DistributedArray.jl, get the slice of matrix
-    size Asize on each dimension with chunks.
-
-TBW
+Borrowed form DistributedArray.jl, get the slice of matrix
+size Asize on each dimension with nchunk.
+*从 [MPIArray4MoMs](https://github.com/deltaeecs/MPIArray4MoMs.jl) 借的！
+为的是避免提前引入 MPI 导致在集群上的 bug。因此该函数的修改必须与 
+[MPIArray4MoMs](https://github.com/deltaeecs/MPIArray4MoMs.jl) 同步。*
 """
-function sizeChunks2idxs(Asize, chunks)
-    cuts = sizeChunks2cuts(Asize, chunks)
-    return sizeChunksCuts2indices(Asize, chunks, cuts)
+function sizeChunks2idxs(Asize, nchunk)
+    cuts = sizeChunks2cuts(Asize, nchunk)
+    return sizeChunksCuts2indices(Asize, nchunk, cuts)
 end


### PR DESCRIPTION
修复为较小目标 MPI 进程保存数据时，叶层太小引起 MPI 数据分区不全在盒子方向导致的基函数划分区间重叠问题。